### PR TITLE
Updated mix.exs to call `package()` explicitly

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,12 +3,12 @@ defmodule Latlong.Mixfile do
 
   def project do
     [app: :latlong,
-     version: "0.1.0",
+     version: "0.1.1",
      elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      description: "Latitude, Longitude Parser",
-     package: package,
+     package: package(),
      deps: deps(),
 
      # Docs


### PR DESCRIPTION
Currently getting warnings when build:

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name

After this change, the warning is gone.